### PR TITLE
chore(deps): bump antelope interface dependencies to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
     "test": "src/test/antelope.test.ts"
   },
   "dependencies": {
-    "@antelopejs/interface-api": "^0.0.2",
-    "@antelopejs/interface-auth": "^0.0.2",
-    "@antelopejs/interface-core": "^0.0.2",
+    "@antelopejs/interface-api": "^0.0.5",
+    "@antelopejs/interface-auth": "^0.0.5",
+    "@antelopejs/interface-core": "^0.0.5",
     "chai": "^4.5.0",
     "jsonwebtoken": "^9.0.3",
     "mocha": "^11.7.5"

--- a/playground/antelope.config.ts
+++ b/playground/antelope.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
       source: {
         type: "package",
         package: "@antelopejs/api",
-        version: "1.0.0",
+        version: "1.1.1",
       },
       config: {
         servers: [

--- a/playground/package.json
+++ b/playground/package.json
@@ -7,8 +7,8 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@antelopejs/interface-auth": "^0.0.2",
-    "@antelopejs/interface-core": "^0.0.2"
+    "@antelopejs/interface-auth": "^0.0.5",
+    "@antelopejs/interface-core": "^0.0.5"
   },
   "devDependencies": {
     "@types/node": "^20.5.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
   .:
     dependencies:
       '@antelopejs/interface-api':
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.5
+        version: 0.0.5(@antelopejs/interface-core@0.0.5)
       '@antelopejs/interface-auth':
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.5
+        version: 0.0.5(@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.5))(@antelopejs/interface-core@0.0.5)
       '@antelopejs/interface-core':
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.5
+        version: 0.0.5
       chai:
         specifier: ^4.5.0
         version: 4.5.0
@@ -64,11 +64,11 @@ importers:
   playground:
     dependencies:
       '@antelopejs/interface-auth':
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.5
+        version: 0.0.5(@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.5))(@antelopejs/interface-core@0.0.5)
       '@antelopejs/interface-core':
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.5
+        version: 0.0.5
     devDependencies:
       '@types/node':
         specifier: ^20.5.7
@@ -82,14 +82,19 @@ importers:
 
 packages:
 
-  '@antelopejs/interface-api@0.0.2':
-    resolution: {integrity: sha512-wD9kODuc5cns8mCVv4hLL3N8eF2iXtXoMgtDS7zJ3hZZoPnlpxZ7mDP4fMRUDBl0pm9ZTPKb5abzu3BZg6T/EA==}
+  '@antelopejs/interface-api@0.0.5':
+    resolution: {integrity: sha512-BApviHE1vVkORDWtC8x8N2xCxBdFZZnhgMlxDuUmlXz2fGlYqBX1inIQQrEyOY31Zc/WN7nJpcA0zjjwk7Sp9A==}
+    peerDependencies:
+      '@antelopejs/interface-core': '>=0.0.3 <1.0.0'
 
-  '@antelopejs/interface-auth@0.0.2':
-    resolution: {integrity: sha512-ts4deh1MYEDe4yKpZ+DFaHVralLcFTbrMh7DxtKAxoByhmDIj6jaX/vAzBmw1n+v37Y4lZSdcqDWrHaYUBwbrw==}
+  '@antelopejs/interface-auth@0.0.5':
+    resolution: {integrity: sha512-/WGlwVcERMRuZApv23VQO0158VXAzsxfPA6ZWSJEJnWHwAkjfw+6UkkDGC46ylIl0/He0OjBnzuSehf1ONVHnw==}
+    peerDependencies:
+      '@antelopejs/interface-api': '>=0.0.3 <1.0.0'
+      '@antelopejs/interface-core': '>=0.0.3 <1.0.0'
 
-  '@antelopejs/interface-core@0.0.2':
-    resolution: {integrity: sha512-CmtOJvSCRj20GOQhrE0PpHybGaW1G1lrepiKHVJa/bclhrvFYgHV0MH84TMpMOHESQT/+wuup007tfXAwaI+Eg==}
+  '@antelopejs/interface-core@0.0.5':
+    resolution: {integrity: sha512-4H6hpFfiK2+DE8vL2mEtPbq1WNch9lt40QNr9KjBrOAtnuq/zMfIlzhbEsda39m+FVkMWXfUYoVolRogVKCLIQ==}
 
   '@biomejs/biome@2.3.2':
     resolution: {integrity: sha512-8e9tzamuDycx7fdrcJ/F/GDZ8SYukc5ud6tDicjjFqURKYFSWMl0H0iXNXZEGmcmNUmABgGuHThPykcM41INgg==}
@@ -1655,16 +1660,16 @@ packages:
 
 snapshots:
 
-  '@antelopejs/interface-api@0.0.2':
+  '@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.5)':
     dependencies:
-      '@antelopejs/interface-core': 0.0.2
+      '@antelopejs/interface-core': 0.0.5
 
-  '@antelopejs/interface-auth@0.0.2':
+  '@antelopejs/interface-auth@0.0.5(@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.5))(@antelopejs/interface-core@0.0.5)':
     dependencies:
-      '@antelopejs/interface-api': 0.0.2
-      '@antelopejs/interface-core': 0.0.2
+      '@antelopejs/interface-api': 0.0.5(@antelopejs/interface-core@0.0.5)
+      '@antelopejs/interface-core': 0.0.5
 
-  '@antelopejs/interface-core@0.0.2':
+  '@antelopejs/interface-core@0.0.5':
     dependencies:
       reflect-metadata: 0.2.2
 


### PR DESCRIPTION
Bump `@antelopejs/interface-*` (and playground/config) to latest published versions. Interfaces stay in `dependencies`. Verified: install, build, lint.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps all `@antelopejs/interface-*` packages from `^0.0.2` to `^0.0.5` in both the root and playground workspaces, and advances the `@antelopejs/api` runtime version in the playground config from `1.0.0` to `1.1.1`.

- **Peer dependency model change**: From `0.0.5`, `interface-api` and `interface-auth` moved `interface-core` (and `interface-api` for `interface-auth`) from regular to peer dependencies. Both `package.json` files already list all three packages explicitly, so every peer dep is satisfied and the pnpm lock file resolves them correctly.
- **Lock file**: Updated consistently, with the new parenthesized peer-dep identifiers in snapshot keys (`@antelopejs/interface-auth@0.0.5(@antelopejs/interface-api@...)`), confirming a clean `pnpm install` was run.
- **No source-code or test changes**: Only manifests and the lock file are touched; runtime behavior is unchanged beyond the version upgrades.

<h3>Confidence Score: 5/5</h3>

Safe to merge — only manifest and lock file changes, no source code touched.

All changes are confined to version numbers in package manifests and the regenerated lock file. The peer dependency model introduced in 0.0.5 is fully satisfied by the packages already listed as dependencies in both workspaces, and the lock file confirms clean resolution with no duplicate or conflicting versions.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Bumps @antelopejs/interface-{api,auth,core} from ^0.0.2 to ^0.0.5 in dependencies; all three peer deps introduced in 0.0.5 are satisfied by co-listed packages. |
| playground/antelope.config.ts | Updates @antelopejs/api runtime package version reference from 1.0.0 to 1.1.1; no structural changes. |
| playground/package.json | Mirrors root package.json bump for @antelopejs/interface-{auth,core} from ^0.0.2 to ^0.0.5; consistent with root. |
| pnpm-lock.yaml | Lock file regenerated; interface packages now resolved as peerDependencies (>=0.0.3 <1.0.0) with correct parenthesized snapshot keys — all peer deps satisfied by explicitly listed packages. |

</details>

</details>

<h3>Entity Relationship Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
erDiagram
    ROOT_PKG {
        string interface-api "^0.0.5 (was 0.0.2)"
        string interface-auth "^0.0.5 (was 0.0.2)"
        string interface-core "^0.0.5 (was 0.0.2)"
    }
    PLAYGROUND_PKG {
        string interface-auth "^0.0.5 (was 0.0.2)"
        string interface-core "^0.0.5 (was 0.0.2)"
    }
    INTERFACE_API_0_0_5 {
        string peerDep "interface-core >=0.0.3 <1.0.0"
    }
    INTERFACE_AUTH_0_0_5 {
        string peerDep1 "interface-api >=0.0.3 <1.0.0"
        string peerDep2 "interface-core >=0.0.3 <1.0.0"
    }
    INTERFACE_CORE_0_0_5 {
        string dep "reflect-metadata 0.2.2"
    }
    ROOT_PKG ||--|| INTERFACE_API_0_0_5 : "depends on"
    ROOT_PKG ||--|| INTERFACE_AUTH_0_0_5 : "depends on"
    ROOT_PKG ||--|| INTERFACE_CORE_0_0_5 : "depends on"
    PLAYGROUND_PKG ||--|| INTERFACE_AUTH_0_0_5 : "depends on"
    PLAYGROUND_PKG ||--|| INTERFACE_CORE_0_0_5 : "depends on"
    INTERFACE_API_0_0_5 ||--|| INTERFACE_CORE_0_0_5 : "peer"
    INTERFACE_AUTH_0_0_5 ||--|| INTERFACE_API_0_0_5 : "peer"
    INTERFACE_AUTH_0_0_5 ||--|| INTERFACE_CORE_0_0_5 : "peer"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
erDiagram
    ROOT_PKG {
        string interface-api "^0.0.5 (was 0.0.2)"
        string interface-auth "^0.0.5 (was 0.0.2)"
        string interface-core "^0.0.5 (was 0.0.2)"
    }
    PLAYGROUND_PKG {
        string interface-auth "^0.0.5 (was 0.0.2)"
        string interface-core "^0.0.5 (was 0.0.2)"
    }
    INTERFACE_API_0_0_5 {
        string peerDep "interface-core >=0.0.3 <1.0.0"
    }
    INTERFACE_AUTH_0_0_5 {
        string peerDep1 "interface-api >=0.0.3 <1.0.0"
        string peerDep2 "interface-core >=0.0.3 <1.0.0"
    }
    INTERFACE_CORE_0_0_5 {
        string dep "reflect-metadata 0.2.2"
    }
    ROOT_PKG ||--|| INTERFACE_API_0_0_5 : "depends on"
    ROOT_PKG ||--|| INTERFACE_AUTH_0_0_5 : "depends on"
    ROOT_PKG ||--|| INTERFACE_CORE_0_0_5 : "depends on"
    PLAYGROUND_PKG ||--|| INTERFACE_AUTH_0_0_5 : "depends on"
    PLAYGROUND_PKG ||--|| INTERFACE_CORE_0_0_5 : "depends on"
    INTERFACE_API_0_0_5 ||--|| INTERFACE_CORE_0_0_5 : "peer"
    INTERFACE_AUTH_0_0_5 ||--|| INTERFACE_API_0_0_5 : "peer"
    INTERFACE_AUTH_0_0_5 ||--|| INTERFACE_CORE_0_0_5 : "peer"
```

</a>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump antelope interface dep..."](https://github.com/antelopejs/auth-jwt/commit/23aa5e0a6814b0402fce3d63aaddaebebbbe19aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37904067)</sub>

<!-- /greptile_comment -->