### PR TITLE
chore(deps): use floating semver ranges for antelope modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
     "test": "src/test/antelope.test.ts"
   },
   "dependencies": {
-    "@antelopejs/interface-api": "^0.0.5",
+    "@antelopejs/interface-api": "^0.0.8",
     "@antelopejs/interface-auth": "^0.0.5",
-    "@antelopejs/interface-core": "^0.0.5",
+    "@antelopejs/interface-core": "^0.0.6",
     "chai": "^4.5.0",
     "jsonwebtoken": "^9.0.3",
     "mocha": "^11.7.5"

--- a/playground/antelope.config.ts
+++ b/playground/antelope.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
       source: {
         type: "package",
         package: "@antelopejs/api",
-        version: "1.1.1",
+        version: "^1.1.3",
       },
       config: {
         servers: [

--- a/playground/package.json
+++ b/playground/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@antelopejs/interface-auth": "^0.0.5",
-    "@antelopejs/interface-core": "^0.0.5"
+    "@antelopejs/interface-core": "^0.0.6"
   },
   "devDependencies": {
     "@types/node": "^20.5.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
   .:
     dependencies:
       '@antelopejs/interface-api':
-        specifier: ^0.0.5
-        version: 0.0.5(@antelopejs/interface-core@0.0.5)
+        specifier: ^0.0.8
+        version: 0.0.8(@antelopejs/interface-core@0.0.6)
       '@antelopejs/interface-auth':
         specifier: ^0.0.5
-        version: 0.0.5(@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.5))(@antelopejs/interface-core@0.0.5)
+        version: 0.0.5(@antelopejs/interface-api@0.0.8(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)
       '@antelopejs/interface-core':
-        specifier: ^0.0.5
-        version: 0.0.5
+        specifier: ^0.0.6
+        version: 0.0.6
       chai:
         specifier: ^4.5.0
         version: 4.5.0
@@ -65,10 +65,10 @@ importers:
     dependencies:
       '@antelopejs/interface-auth':
         specifier: ^0.0.5
-        version: 0.0.5(@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.5))(@antelopejs/interface-core@0.0.5)
+        version: 0.0.5(@antelopejs/interface-api@0.0.8(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)
       '@antelopejs/interface-core':
-        specifier: ^0.0.5
-        version: 0.0.5
+        specifier: ^0.0.6
+        version: 0.0.6
     devDependencies:
       '@types/node':
         specifier: ^20.5.7
@@ -82,8 +82,8 @@ importers:
 
 packages:
 
-  '@antelopejs/interface-api@0.0.5':
-    resolution: {integrity: sha512-BApviHE1vVkORDWtC8x8N2xCxBdFZZnhgMlxDuUmlXz2fGlYqBX1inIQQrEyOY31Zc/WN7nJpcA0zjjwk7Sp9A==}
+  '@antelopejs/interface-api@0.0.8':
+    resolution: {integrity: sha512-LWXPsbvkCG2AblP6r0+h4K0v3jxSpAoE/1SG5pkTPspaSa+H3aYvBiRwKphmISw0/4YU801OG5dfxeV5gNu/jA==}
     peerDependencies:
       '@antelopejs/interface-core': '>=0.0.3 <1.0.0'
 
@@ -93,8 +93,8 @@ packages:
       '@antelopejs/interface-api': '>=0.0.3 <1.0.0'
       '@antelopejs/interface-core': '>=0.0.3 <1.0.0'
 
-  '@antelopejs/interface-core@0.0.5':
-    resolution: {integrity: sha512-4H6hpFfiK2+DE8vL2mEtPbq1WNch9lt40QNr9KjBrOAtnuq/zMfIlzhbEsda39m+FVkMWXfUYoVolRogVKCLIQ==}
+  '@antelopejs/interface-core@0.0.6':
+    resolution: {integrity: sha512-OMna86iT/ylL6wJl6FCPw9ieddULXGs4jTmeiDBNEXYQ9acnVXjS/+SaN0UR0h7oY7WTD9VwKXVwG95qjNIA1w==}
 
   '@biomejs/biome@2.3.2':
     resolution: {integrity: sha512-8e9tzamuDycx7fdrcJ/F/GDZ8SYukc5ud6tDicjjFqURKYFSWMl0H0iXNXZEGmcmNUmABgGuHThPykcM41INgg==}
@@ -1660,16 +1660,16 @@ packages:
 
 snapshots:
 
-  '@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.5)':
+  '@antelopejs/interface-api@0.0.8(@antelopejs/interface-core@0.0.6)':
     dependencies:
-      '@antelopejs/interface-core': 0.0.5
+      '@antelopejs/interface-core': 0.0.6
 
-  '@antelopejs/interface-auth@0.0.5(@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.5))(@antelopejs/interface-core@0.0.5)':
+  '@antelopejs/interface-auth@0.0.5(@antelopejs/interface-api@0.0.8(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)':
     dependencies:
-      '@antelopejs/interface-api': 0.0.5(@antelopejs/interface-core@0.0.5)
-      '@antelopejs/interface-core': 0.0.5
+      '@antelopejs/interface-api': 0.0.8(@antelopejs/interface-core@0.0.6)
+      '@antelopejs/interface-core': 0.0.6
 
-  '@antelopejs/interface-core@0.0.5':
+  '@antelopejs/interface-core@0.0.6':
     dependencies:
       reflect-metadata: 0.2.2
 


### PR DESCRIPTION
## What

- Reference antelope modules in `playground/antelope.config.ts` with a floating range (`@antelopejs/api`: `1.1.1` → `^1.1.3`).
- Bump antelope dependencies to the latest published versions across all `package.json` files:
  - `@antelopejs/interface-api`: `^0.0.5` → `^0.0.8`
  - `@antelopejs/interface-core`: `^0.0.5` → `^0.0.6`
  - `@antelopejs/interface-auth`: unchanged (already at latest `^0.0.5`)
- Refresh `pnpm-lock.yaml`.

## Why

Now that `@antelopejs/core` 1.4.5 supports floating semver ranges in `antelope.config`, using `^x.y.z` keeps antelope module versions current automatically instead of pinning a frozen version. Local modules are untouched.

Verified: `pnpm build`, `tsc --noEmit`, and `biome check` all pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates antelope module dependencies to their latest published versions and switches the `playground/antelope.config.ts` module reference from an exact pin to a caret range, taking advantage of floating semver support added in `@antelopejs/core` 1.4.5.

- Bumps `@antelopejs/interface-api` to `^0.0.8` and `@antelopejs/interface-core` to `^0.0.6` in both `package.json` files; `@antelopejs/interface-auth` is left at `^0.0.5` as no newer version is available.
- Switches `@antelopejs/api` in `playground/antelope.config.ts` from a pinned `1.1.1` to `^1.1.3` (note: `1.1.2` is skipped), moving to the current latest minor release.
- `pnpm-lock.yaml` is fully regenerated with consistent resolved versions and integrity hashes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are dependency version bumps with a consistent, regenerated lockfile and no logic changes.

The diff is limited to version specifier updates in two package.json files, a config version string change, and the corresponding lockfile regeneration. The resolved peer dependency graph in the lockfile is internally consistent (interface-auth@0.0.5 resolves correctly against api@0.0.8 and core@0.0.6 within the declared >=0.0.3 <1.0.0 peer range). No application logic, tests, or build configuration were modified.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Bumps @antelopejs/interface-api from ^0.0.5 to ^0.0.8 and @antelopejs/interface-core from ^0.0.5 to ^0.0.6; @antelopejs/interface-auth is intentionally left at ^0.0.5. |
| playground/antelope.config.ts | Switches @antelopejs/api from an exact pin (1.1.1) to a floating caret range (^1.1.3), skipping 1.1.2; consistent with @antelopejs/core 1.4.5 floating-range support. |
| playground/package.json | Bumps @antelopejs/interface-core from ^0.0.5 to ^0.0.6 to match the root package.json; @antelopejs/interface-auth remains at ^0.0.5. |
| pnpm-lock.yaml | Lockfile updated consistently: resolved versions and integrity hashes align with the new specifiers in all package.json files. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[package.json / playground/package.json] -->|declares| B["@antelopejs/interface-api ^0.0.8"]
    A -->|declares| C["@antelopejs/interface-core ^0.0.6"]
    A -->|declares| D["@antelopejs/interface-auth ^0.0.5 (unchanged)"]
    B --> E[pnpm-lock.yaml resolves 0.0.8]
    C --> F[pnpm-lock.yaml resolves 0.0.6]
    D --> G["pnpm-lock.yaml resolves 0.0.5 (peer: api@0.0.8, core@0.0.6)"]
    H[playground/antelope.config.ts] -->|module source| I["@antelopejs/api ^1.1.3 (was 1.1.1)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[package.json / playground/package.json] -->|declares| B["@antelopejs/interface-api ^0.0.8"]
    A -->|declares| C["@antelopejs/interface-core ^0.0.6"]
    A -->|declares| D["@antelopejs/interface-auth ^0.0.5 (unchanged)"]
    B --> E[pnpm-lock.yaml resolves 0.0.8]
    C --> F[pnpm-lock.yaml resolves 0.0.6]
    D --> G["pnpm-lock.yaml resolves 0.0.5 (peer: api@0.0.8, core@0.0.6)"]
    H[playground/antelope.config.ts] -->|module source| I["@antelopejs/api ^1.1.3 (was 1.1.1)"]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): use floating semver ranges ..."](https://github.com/antelopejs/auth-jwt/commit/b1033889370a4f01b969e39bcc7545da27c7976c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44401552)</sub>

<!-- /greptile_comment -->